### PR TITLE
chore: Include Jest config for functional tests in transpiled output

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,5 @@
     "types": ["node", "jest"],
     "typeRoots": ["node_modules/@types", "src/types"]
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "src/**/*.mjs"]
 }


### PR DESCRIPTION
This gets rid of the respective ESLint error, but more importantly, we'll need this once we start running the functional test suite in CI.
