### PR TITLE
chore: Integrate authentication library

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 VeraId Certificate Authority (CA) server.
 
+## Environment variables
+
+- `AUTHORITY_VERSION` (required). The version of this server.
+- `MONGODB_URI` (required).
+- OAuth2 authentication:
+  - `OAUTH2_JWKS_URL` (required). The URL to the JWKS endpoint of the authorisation server.
+  - Either `OAUTH2_TOKEN_ISSUER` or `OAUTH2_TOKEN_ISSUER_REGEX` (required). The (URL of the) authorisation server.
+  - `OAUTH2_TOKEN_AUDIENCE` (required). The identifier of the current instance of this server (typically its public URL).
+
 ## Development
 
 This app requires the following system dependencies:

--- a/k8s/mock-authz-server.yml
+++ b/k8s/mock-authz-server.yml
@@ -1,0 +1,13 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: mock-authz-server
+spec:
+  template:
+    spec:
+      containers:
+        - name: mock-oauth2-server
+          image: ghcr.io/navikt/mock-oauth2-server:0.5.8
+          readinessProbe:
+            httpGet:
+              path: /default/.well-known/openid-configuration

--- a/k8s/service.yml
+++ b/k8s/service.yml
@@ -28,3 +28,6 @@ spec:
                   key: mongodb_password
             - name: MONGODB_URI
               value: mongodb://$(MONGODB_USERNAME):$(MONGODB_PASSWORD)@mongodb
+
+            - name: OAUTH2_JWKS_URL
+              value: http://mock-authz-server.default/default/jwks

--- a/k8s/service.yml
+++ b/k8s/service.yml
@@ -31,6 +31,10 @@ spec:
 
             - name: OAUTH2_JWKS_URL
               value: http://mock-authz-server.default/default/jwks
+            - name: OAUTH2_TOKEN_AUDIENCE
+              value: default
+            - name: OAUTH2_TOKEN_ISSUER_REGEX
+              value: ^http://[^/]+/default$
 
             # Mock AWS KMS (used by WebCrypto KMS)
             - name: KMS_ADAPTER

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@typegoose/typegoose": "^10.3.3",
         "env-var": "^7.3.0",
         "fastify": "^4.14.0",
+        "fastify-auth0-verify": "github:relaycorp/fastify-auth0-verify#auth0-agnostic-generated",
         "fastify-plugin": "^4.5.0",
         "is-valid-domain": "^0.1.6",
         "json-schema-to-ts": "^2.7.2",
@@ -2889,6 +2890,15 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
+    "node_modules/@fastify/cookie": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@fastify/cookie/-/cookie-8.3.0.tgz",
+      "integrity": "sha512-P9hY9GO11L20TnZ33XN3i0bt+3x0zaT7S0ohAzWO950E9PB2xnNhLYzPFJIGFi5AVN0yr5+/iZhWxeYvR6KCzg==",
+      "dependencies": {
+        "cookie": "^0.5.0",
+        "fastify-plugin": "^4.0.0"
+      }
+    },
     "node_modules/@fastify/deepmerge": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-1.3.0.tgz",
@@ -2905,6 +2915,18 @@
       "integrity": "sha512-ypZynRvXA3dibfPykQN3RB5wBdEUgSGgny8Qc6k163wYPLD4mEGEDkACp+00YmqkGvIm8D/xYoHajwyEdWD/eg==",
       "dependencies": {
         "fast-json-stringify": "^5.0.0"
+      }
+    },
+    "node_modules/@fastify/jwt": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@fastify/jwt/-/jwt-6.7.1.tgz",
+      "integrity": "sha512-pvRcGeyF2H1U+HXaxlRBd6s1y99vbSZjhpxTWECIGIhMXKRxBTBSUPRF7LJGONlW1/pZstQ0/Dp/ZxBFlDuEnw==",
+      "dependencies": {
+        "@fastify/error": "^3.0.0",
+        "@lukeed/ms": "^2.0.0",
+        "fast-jwt": "^2.0.0",
+        "fastify-plugin": "^4.0.0",
+        "steed": "^1.1.3"
       }
     },
     "node_modules/@fastify/routes": {
@@ -3540,6 +3562,14 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
+    },
+    "node_modules/@lukeed/ms": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.1.tgz",
+      "integrity": "sha512-Xs/4RZltsAL7pkvaNStUQt7netTkyxrS0K+RILcVr3TRMS/ToOg4I6uNfhB9SlGsnWBym4U+EaXq0f0cEMNkHA==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
@@ -7157,6 +7187,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/asn1js": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
@@ -7496,6 +7537,11 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/bowser": {
       "version": "2.11.0",
@@ -8036,6 +8082,14 @@
         "node": ">=12"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/clone-response": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
@@ -8501,6 +8555,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/dequal": {
@@ -10411,6 +10473,19 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
+    "node_modules/fast-jwt": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/fast-jwt/-/fast-jwt-2.2.1.tgz",
+      "integrity": "sha512-r5zKugIE/4ZgGv98fE6wtIglkOwMVJOlYVa/nXyivAV56sLtAtH1eJX+WiZAwOgy387PJeZdBQsjfJhoPwOqvA==",
+      "dependencies": {
+        "asn1.js": "^5.4.1",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "mnemonist": "^0.39.5"
+      },
+      "engines": {
+        "node": ">=14 <20"
+      }
+    },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -10466,6 +10541,17 @@
         "node": ">= 4.9.1"
       }
     },
+    "node_modules/fastfall": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/fastfall/-/fastfall-1.5.1.tgz",
+      "integrity": "sha512-KH6p+Z8AKPXnmA7+Iz2Lh8ARCMr+8WNPVludm1LGkZoD2MjY6LVnRMtTKhkdzI+jr0RzQWXKzKyBJm1zoHEL4Q==",
+      "dependencies": {
+        "reusify": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/fastify": {
       "version": "4.15.0",
       "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.15.0.tgz",
@@ -10486,6 +10572,22 @@
         "secure-json-parse": "^2.5.0",
         "semver": "^7.3.7",
         "tiny-lru": "^10.0.0"
+      }
+    },
+    "node_modules/fastify-auth0-verify": {
+      "version": "1.1.0",
+      "resolved": "git+ssh://git@github.com/relaycorp/fastify-auth0-verify.git#e9f04fef815e0a9a7c77633328e40d4ef271bc23",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@fastify/cookie": "^8.0.0",
+        "@fastify/jwt": "^6.1.0",
+        "fastify-plugin": "^4.0.0",
+        "http-errors": "^2.0.0",
+        "node-cache": "^5.0.1",
+        "node-fetch": "^2.6.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/fastify-plugin": {
@@ -10523,12 +10625,30 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
+    "node_modules/fastparallel": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/fastparallel/-/fastparallel-2.4.1.tgz",
+      "integrity": "sha512-qUmhxPgNHmvRjZKBFUNI0oZuuH9OlSIOXmJ98lhKPxMZZ7zS/Fi0wRHOihDSz0R1YiIOjxzOY4bq65YTcdBi2Q==",
+      "dependencies": {
+        "reusify": "^1.0.4",
+        "xtend": "^4.0.2"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
       "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fastseries": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/fastseries/-/fastseries-1.7.2.tgz",
+      "integrity": "sha512-dTPFrPGS8SNSzAt7u/CbMKCJ3s01N04s4JFbORHcmyvVfVKmbhMD1VtRbh5enGHxkaQDqWyLefiKOGGmohGDDQ==",
+      "dependencies": {
+        "reusify": "^1.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "node_modules/fb-watchman": {
@@ -11366,6 +11486,21 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
       "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/http2-wrapper": {
       "version": "1.0.3",
@@ -14256,6 +14391,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -14307,6 +14447,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/mnemonist": {
+      "version": "0.39.5",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.39.5.tgz",
+      "integrity": "sha512-FPUtkhtJ0efmEFGpU14x7jGbTB+s18LrzRL2KgoWz9YvcY3cPomz8tih01GbHwnGk/OmkOKfqd/RAQoc8Lm7DQ==",
+      "dependencies": {
+        "obliterator": "^2.0.1"
       }
     },
     "node_modules/mongodb": {
@@ -14686,6 +14834,17 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
       "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
       "optional": true
+    },
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "dependencies": {
+        "clone": "2.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.6.9",
@@ -15134,6 +15293,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obliterator": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.4.tgz",
+      "integrity": "sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ=="
     },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.0",
@@ -17118,6 +17282,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
     "node_modules/saslprep": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
@@ -17170,6 +17339,11 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
       "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ=="
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "node_modules/sha.js": {
       "version": "2.4.11",
@@ -17480,6 +17654,26 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/steed": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/steed/-/steed-1.1.3.tgz",
+      "integrity": "sha512-EUkci0FAUiE4IvGTSKcDJIQ/eRUP2JJb56+fvZ4sdnguLTqIdKjSxUe138poW8mkvKWXW2sFPrgTsxqoISnmoA==",
+      "dependencies": {
+        "fastfall": "^1.5.0",
+        "fastparallel": "^2.2.0",
+        "fastq": "^1.3.0",
+        "fastseries": "^1.7.0",
+        "reusify": "^1.0.0"
       }
     },
     "node_modules/stop-iteration-iterator": {
@@ -18086,6 +18280,14 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/tr46": {
@@ -19314,7 +19516,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4"
       }
@@ -21699,6 +21900,15 @@
         }
       }
     },
+    "@fastify/cookie": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@fastify/cookie/-/cookie-8.3.0.tgz",
+      "integrity": "sha512-P9hY9GO11L20TnZ33XN3i0bt+3x0zaT7S0ohAzWO950E9PB2xnNhLYzPFJIGFi5AVN0yr5+/iZhWxeYvR6KCzg==",
+      "requires": {
+        "cookie": "^0.5.0",
+        "fastify-plugin": "^4.0.0"
+      }
+    },
     "@fastify/deepmerge": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-1.3.0.tgz",
@@ -21715,6 +21925,18 @@
       "integrity": "sha512-ypZynRvXA3dibfPykQN3RB5wBdEUgSGgny8Qc6k163wYPLD4mEGEDkACp+00YmqkGvIm8D/xYoHajwyEdWD/eg==",
       "requires": {
         "fast-json-stringify": "^5.0.0"
+      }
+    },
+    "@fastify/jwt": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@fastify/jwt/-/jwt-6.7.1.tgz",
+      "integrity": "sha512-pvRcGeyF2H1U+HXaxlRBd6s1y99vbSZjhpxTWECIGIhMXKRxBTBSUPRF7LJGONlW1/pZstQ0/Dp/ZxBFlDuEnw==",
+      "requires": {
+        "@fastify/error": "^3.0.0",
+        "@lukeed/ms": "^2.0.0",
+        "fast-jwt": "^2.0.0",
+        "fastify-plugin": "^4.0.0",
+        "steed": "^1.1.3"
       }
     },
     "@fastify/routes": {
@@ -22221,6 +22443,11 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
+    },
+    "@lukeed/ms": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.1.tgz",
+      "integrity": "sha512-Xs/4RZltsAL7pkvaNStUQt7netTkyxrS0K+RILcVr3TRMS/ToOg4I6uNfhB9SlGsnWBym4U+EaXq0f0cEMNkHA=="
     },
     "@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
@@ -24730,6 +24957,17 @@
       "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
       "dev": true
     },
+    "asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "requires": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "asn1js": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
@@ -24983,6 +25221,11 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
+    "bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "bowser": {
       "version": "2.11.0",
@@ -25363,6 +25606,11 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
+    },
     "clone-response": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
@@ -25699,6 +25947,11 @@
         "del": "^7.0.0",
         "meow": "^10.1.3"
       }
+    },
+    "depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
     },
     "dequal": {
       "version": "2.0.3",
@@ -27100,6 +27353,16 @@
         }
       }
     },
+    "fast-jwt": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/fast-jwt/-/fast-jwt-2.2.1.tgz",
+      "integrity": "sha512-r5zKugIE/4ZgGv98fE6wtIglkOwMVJOlYVa/nXyivAV56sLtAtH1eJX+WiZAwOgy387PJeZdBQsjfJhoPwOqvA==",
+      "requires": {
+        "asn1.js": "^5.4.1",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "mnemonist": "^0.39.5"
+      }
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -27141,6 +27404,14 @@
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
       "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
       "dev": true
+    },
+    "fastfall": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/fastfall/-/fastfall-1.5.1.tgz",
+      "integrity": "sha512-KH6p+Z8AKPXnmA7+Iz2Lh8ARCMr+8WNPVludm1LGkZoD2MjY6LVnRMtTKhkdzI+jr0RzQWXKzKyBJm1zoHEL4Q==",
+      "requires": {
+        "reusify": "^1.0.0"
+      }
     },
     "fastify": {
       "version": "4.15.0",
@@ -27187,10 +27458,31 @@
         }
       }
     },
+    "fastify-auth0-verify": {
+      "version": "git+ssh://git@github.com/relaycorp/fastify-auth0-verify.git#e9f04fef815e0a9a7c77633328e40d4ef271bc23",
+      "from": "fastify-auth0-verify@github:relaycorp/fastify-auth0-verify#auth0-agnostic-generated",
+      "requires": {
+        "@fastify/cookie": "^8.0.0",
+        "@fastify/jwt": "^6.1.0",
+        "fastify-plugin": "^4.0.0",
+        "http-errors": "^2.0.0",
+        "node-cache": "^5.0.1",
+        "node-fetch": "^2.6.1"
+      }
+    },
     "fastify-plugin": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-4.5.0.tgz",
       "integrity": "sha512-79ak0JxddO0utAXAQ5ccKhvs6vX2MGyHHMMsmZkBANrq3hXc1CHzvNPHOcvTsVMEPl5I+NT+RO4YKMGehOfSIg=="
+    },
+    "fastparallel": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/fastparallel/-/fastparallel-2.4.1.tgz",
+      "integrity": "sha512-qUmhxPgNHmvRjZKBFUNI0oZuuH9OlSIOXmJ98lhKPxMZZ7zS/Fi0wRHOihDSz0R1YiIOjxzOY4bq65YTcdBi2Q==",
+      "requires": {
+        "reusify": "^1.0.4",
+        "xtend": "^4.0.2"
+      }
     },
     "fastq": {
       "version": "1.15.0",
@@ -27198,6 +27490,15 @@
       "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
       "requires": {
         "reusify": "^1.0.4"
+      }
+    },
+    "fastseries": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/fastseries/-/fastseries-1.7.2.tgz",
+      "integrity": "sha512-dTPFrPGS8SNSzAt7u/CbMKCJ3s01N04s4JFbORHcmyvVfVKmbhMD1VtRbh5enGHxkaQDqWyLefiKOGGmohGDDQ==",
+      "requires": {
+        "reusify": "^1.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "fb-watchman": {
@@ -27821,6 +28122,18 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
       "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
+    },
+    "http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "requires": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      }
     },
     "http2-wrapper": {
       "version": "1.0.3",
@@ -29870,6 +30183,11 @@
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true
     },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
     "minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -29907,6 +30225,14 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+    },
+    "mnemonist": {
+      "version": "0.39.5",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.39.5.tgz",
+      "integrity": "sha512-FPUtkhtJ0efmEFGpU14x7jGbTB+s18LrzRL2KgoWz9YvcY3cPomz8tih01GbHwnGk/OmkOKfqd/RAQoc8Lm7DQ==",
+      "requires": {
+        "obliterator": "^2.0.1"
+      }
     },
     "mongodb": {
       "version": "5.2.0",
@@ -30168,6 +30494,14 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
       "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
       "optional": true
+    },
+    "node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "requires": {
+        "clone": "2.x"
+      }
     },
     "node-fetch": {
       "version": "2.6.9",
@@ -30495,6 +30829,11 @@
         "define-properties": "^1.1.4",
         "es-abstract": "^1.20.4"
       }
+    },
+    "obliterator": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.4.tgz",
+      "integrity": "sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ=="
     },
     "on-exit-leak-free": {
       "version": "2.1.0",
@@ -31982,6 +32321,11 @@
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
       "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g=="
     },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
     "saslprep": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
@@ -32028,6 +32372,11 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
       "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ=="
+    },
+    "setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "sha.js": {
       "version": "2.4.11",
@@ -32260,6 +32609,23 @@
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
           "dev": true
         }
+      }
+    },
+    "statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
+    },
+    "steed": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/steed/-/steed-1.1.3.tgz",
+      "integrity": "sha512-EUkci0FAUiE4IvGTSKcDJIQ/eRUP2JJb56+fvZ4sdnguLTqIdKjSxUe138poW8mkvKWXW2sFPrgTsxqoISnmoA==",
+      "requires": {
+        "fastfall": "^1.5.0",
+        "fastparallel": "^2.2.0",
+        "fastq": "^1.3.0",
+        "fastseries": "^1.7.0",
+        "reusify": "^1.0.0"
       }
     },
     "stop-iteration-iterator": {
@@ -32730,6 +33096,11 @@
       "requires": {
         "is-number": "^7.0.0"
       }
+    },
+    "toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
     "tr46": {
       "version": "3.0.0",
@@ -33635,8 +34006,7 @@
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@typegoose/typegoose": "^10.3.3",
     "env-var": "^7.3.0",
     "fastify": "^4.14.0",
+    "fastify-auth0-verify": "github:relaycorp/fastify-auth0-verify#auth0-agnostic-generated",
     "fastify-plugin": "^4.5.0",
     "is-valid-domain": "^0.1.6",
     "json-schema-to-ts": "^2.7.2",

--- a/src/services/fastify.ts
+++ b/src/services/fastify.ts
@@ -1,15 +1,16 @@
 import type { JsonSchemaToTsProvider } from '@fastify/type-provider-json-schema-to-ts';
+import fastifyOauth2Verify, { type FastifyAuth0VerifyOptions } from 'fastify-auth0-verify';
 import env from 'env-var';
 import {
   fastify,
   type FastifyBaseLogger,
-  type RawReplyDefaultExpression,
-  type RawRequestDefaultExpression,
-  type RawServerDefault,
   type FastifyInstance,
   type FastifyPluginCallback,
   type FastifyPluginOptions,
   type HTTPMethods,
+  type RawReplyDefaultExpression,
+  type RawRequestDefaultExpression,
+  type RawServerDefault,
 } from 'fastify';
 import type { Logger } from 'pino';
 
@@ -19,6 +20,26 @@ import { makeLogger } from '../utilities/logging.js';
 const DEFAULT_REQUEST_ID_HEADER = 'X-Request-Id';
 const SERVER_PORT = 8080;
 const SERVER_HOST = '0.0.0.0';
+
+function getOauth2PluginOptions(): FastifyAuth0VerifyOptions {
+  const audience = env.get('OAUTH2_TOKEN_AUDIENCE').required().asString();
+  const domain = env.get('OAUTH2_JWKS_URL').required().asUrlString();
+
+  const issuer = env.get('OAUTH2_TOKEN_ISSUER').asUrlString();
+  const issuerRegex = env.get('OAUTH2_TOKEN_ISSUER_REGEX').asRegExp('u');
+  if (
+    (issuer === undefined && issuerRegex === undefined) ||
+    (issuer !== undefined && issuerRegex !== undefined)
+  ) {
+    throw new Error('Either OAUTH2_TOKEN_ISSUER or OAUTH2_TOKEN_ISSUER_REGEX should be set');
+  }
+
+  return {
+    audience,
+    domain,
+    issuer: issuer ?? (issuerRegex as any),
+  };
+}
 
 export const HTTP_METHODS: readonly HTTPMethods[] = [
   'POST',
@@ -62,6 +83,9 @@ export async function configureFastify<PluginOptions extends FastifyPluginOption
 
     trustProxy: true,
   });
+
+  const verifyOptions = getOauth2PluginOptions();
+  await server.register(fastifyOauth2Verify, verifyOptions);
 
   await Promise.all(plugins.map((plugin) => server.register(plugin, pluginOptions)));
 

--- a/src/testUtils/authn.ts
+++ b/src/testUtils/authn.ts
@@ -1,0 +1,5 @@
+export const OAUTH2_JWKS_URL = 'https://authn.idp.example/.well-known/jwks.json';
+
+export const OAUTH2_TOKEN_ISSUER = 'https://idp.example/';
+
+export const OAUTH2_TOKEN_AUDIENCE = 'the audience';

--- a/src/testUtils/envVars.ts
+++ b/src/testUtils/envVars.ts
@@ -1,6 +1,7 @@
 import { jest } from '@jest/globals';
 import envVar from 'env-var';
 
+import { OAUTH2_JWKS_URL, OAUTH2_TOKEN_AUDIENCE, OAUTH2_TOKEN_ISSUER } from './authn.js';
 import { MONGODB_URI } from './db.js';
 
 interface EnvVarSet {
@@ -10,6 +11,9 @@ interface EnvVarSet {
 export const REQUIRED_SERVER_ENV_VARS = {
   AUTHORITY_VERSION: '1.2.3',
   MONGODB_URI,
+  OAUTH2_JWKS_URL,
+  OAUTH2_TOKEN_AUDIENCE,
+  OAUTH2_TOKEN_ISSUER,
 };
 
 export function configureMockEnvVars(envVars: EnvVarSet = {}): (envVars: EnvVarSet) => void {


### PR DESCRIPTION
Fixes #2.

High-level changes:

- Integrate [`mock-oauth2-server`](https://github.com/navikt/mock-oauth2-server) in development.
- Integrate fork of [`fastify-auth0-verify`](https://github.com/nearform/fastify-auth0-verify). See #82.

#84 will actually use `request.user` to enforce authorisation, so no endpoint is being updated to enforce authorisation here.

# Testing

This PR can be verified by creating the dummy route `GET /authn` as follows:

```diff
diff --git a/src/services/routes/healthcheck.routes.ts b/src/services/routes/healthcheck.routes.ts
index 7b7abe7..6cf48d3 100644
--- a/src/services/routes/healthcheck.routes.ts
+++ b/src/services/routes/healthcheck.routes.ts
@@ -20,5 +20,15 @@ export default function registerRoutes(
     },
   });
 
+  fastify.route({
+    method: ['GET'],
+    url: '/authn',
+    preValidation: fastify.authenticate,
+
+    async handler(request, reply): Promise<void> {
+      await reply.code(HTTP_STATUS_CODES.OK).send(request.user);
+    },
```

Then making requests to it as follows:

```http
### Make anonymous request
GET http://veraid-authority.default.10.103.177.106.sslip.io/authn

### Make authenticated request with invalid credentials
GET http://veraid-authority.default.10.103.177.106.sslip.io/authn
Authorization: Bearer INVALID_TOKEN

### Make authenticated request with valid credentials
GET http://veraid-authority.default.10.103.177.106.sslip.io/authn
Authorization: Bearer <VALID-TOKEN-HERE>
```

`<VALID-TOKEN-HERE>` can be obtained with:

```http
### Authenticate with authorisation server (client credentials)
POST http://mock-authz-server.default.10.103.177.106.sslip.io/default/token
Content-Type: application/x-www-form-urlencoded

grant_type=client_credentials&client_id=admin@example.com&client_secret=s3cr3t
```