### PR TITLE
chore: Get rid of TypeGoose warnings about mixed types

### DIFF
--- a/src/models/Member.model.ts
+++ b/src/models/Member.model.ts
@@ -1,4 +1,4 @@
-import { index, prop } from '@typegoose/typegoose';
+import { index, prop, Severity } from '@typegoose/typegoose';
 
 export enum Role {
   ORG_ADMIN = 'org_admin',
@@ -10,10 +10,10 @@ export enum Role {
   { unique: true, partialFilterExpression: { name: { $type: 'string' } } },
 )
 export class MemberModelSchema {
-  @prop({ default: null })
+  @prop({ default: null, allowMixed: Severity.ALLOW })
   public name!: string | null;
 
-  @prop({ default: null })
+  @prop({ default: null, allowMixed: Severity.ALLOW })
   public email!: string | null;
 
   @prop({ required: true, enum: Role })


### PR DESCRIPTION
These add too much noise.

```
    console.warn
      Setting "Mixed" for property "MemberModelSchema.name"
      Look here for how to disable this message: https://typegoose.github.io/typegoose/docs/api/decorators/model-options/#allowmixed

      39 |       logger: mockLogging.logger,
      40 |     };
    > 41 |     memberModel = getModelForClass(MemberModelSchema, {
         |                   ^
      42 |       existingConnection: connection,
      43 |     });
      44 |   });

      at Object.warnMixed (node_modules/@typegoose/typegoose/src/internal/utils.ts:540:14)
      at processProp (node_modules/@typegoose/typegoose/src/internal/processProp.ts:369:13)
      at _buildSchema (node_modules/@typegoose/typegoose/src/internal/schema.ts:73:18)
      at buildSchema (node_modules/@typegoose/typegoose/src/typegoose.ts:190:21)
      at getModelForClass (node_modules/@typegoose/typegoose/src/typegoose.ts:103:60)
      at Object.<anonymous> (src/member.spec.ts:41:19)

    console.warn
      Setting "Mixed" for property "MemberModelSchema.email"
      Look here for how to disable this message: https://typegoose.github.io/typegoose/docs/api/decorators/model-options/#allowmixed

      39 |       logger: mockLogging.logger,
      40 |     };
    > 41 |     memberModel = getModelForClass(MemberModelSchema, {
         |                   ^
      42 |       existingConnection: connection,
      43 |     });
      44 |   });

      at Object.warnMixed (node_modules/@typegoose/typegoose/src/internal/utils.ts:540:14)
      at processProp (node_modules/@typegoose/typegoose/src/internal/processProp.ts:369:13)
      at _buildSchema (node_modules/@typegoose/typegoose/src/internal/schema.ts:73:18)
      at buildSchema (node_modules/@typegoose/typegoose/src/typegoose.ts:190:21)
      at getModelForClass (node_modules/@typegoose/typegoose/src/typegoose.ts:103:60)
      at Object.<anonymous> (src/member.spec.ts:41:19)
```
