### PR TITLE
fix: Drop support for member access types

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ Unless otherwise specified, all inputs and outputs will be JSON serialised.
   - Auth: Admin.
   - Input:
     - Name (e.g., `acme.com`).
-    - Member access type (`invite-only` or `open`).
     - [Awala endpoint middleware](https://github.com/relaycorp/relayverse/issues/28) URL (optional).
   - Output:
     - VeraId TXT record.

--- a/src/api/routes/org.routes.spec.ts
+++ b/src/api/routes/org.routes.spec.ts
@@ -8,12 +8,7 @@ import {
   NON_ASCII_ORG_NAME,
   ORG_NAME,
 } from '../../testUtils/stubs.js';
-import {
-  type OrgSchema,
-  type OrgSchemaMemberAccessType,
-  orgSchemaMemberAccessTypes,
-  type OrgSchemaPatch,
-} from '../../schemas/org.schema.js';
+import type { OrgSchema, OrgSchemaPatch } from '../../schemas/org.schema.js';
 import type { OrgCreationResult } from '../../orgTypes.js';
 import type { Result, SuccessfulResult } from '../../utilities/result.js';
 import { OrgProblemType } from '../../OrgProblemType.js';
@@ -49,7 +44,7 @@ describe('org routes', () => {
     };
 
     describe('Auth', () => {
-      const payload: OrgSchema = { name: ORG_NAME, memberAccessType: 'INVITE_ONLY' };
+      const payload: OrgSchema = { name: ORG_NAME };
       testOrgRouteAuth('ORG_BULK', { ...injectionOptions, payload }, getTestServerFixture, {
         spy: mockCreateOrg,
         result: { name: ORG_NAME },
@@ -60,10 +55,7 @@ describe('org routes', () => {
       ['ASCII', ORG_NAME],
       ['Non ASCII', NON_ASCII_ORG_NAME],
     ])('%s name should return URLs', async (_type, name: string) => {
-      const payload: OrgSchema = {
-        name,
-        memberAccessType: 'INVITE_ONLY',
-      };
+      const payload: OrgSchema = { name };
       mockCreateOrg.mockResolvedValueOnce({
         didSucceed: true,
 
@@ -85,10 +77,7 @@ describe('org routes', () => {
     });
 
     test('Duplicated name error should resolve into conflict status', async () => {
-      const payload: OrgSchema = {
-        name: ORG_NAME,
-        memberAccessType: 'INVITE_ONLY',
-      };
+      const payload: OrgSchema = { name: ORG_NAME };
       mockCreateOrg.mockResolvedValueOnce({
         didSucceed: false,
         reason: OrgProblemType.EXISTING_ORG_NAME,
@@ -104,10 +93,7 @@ describe('org routes', () => {
     });
 
     test('Malformed name should resolve into bad request status', async () => {
-      const payload: OrgSchema = {
-        name: 'MALFORMED_NAME',
-        memberAccessType: 'INVITE_ONLY',
-      };
+      const payload: OrgSchema = { name: 'MALFORMED_NAME' };
       mockCreateOrg.mockResolvedValueOnce({
         didSucceed: false,
         reason: OrgProblemType.MALFORMED_ORG_NAME,
@@ -122,66 +108,11 @@ describe('org routes', () => {
       expect(response.json()).toHaveProperty('type', OrgProblemType.MALFORMED_ORG_NAME);
     });
 
-    test.each(orgSchemaMemberAccessTypes)(
-      '%s access type should return success',
-      async (memberAccessType: OrgSchemaMemberAccessType) => {
-        const payload: OrgSchema = {
-          name: ORG_NAME,
-          memberAccessType,
-        };
-        mockCreateOrg.mockResolvedValueOnce({
-          didSucceed: true,
-
-          result: {
-            name: 'test',
-          },
-        });
-
-        const response = await serverInstance.inject({
-          ...injectionOptions,
-          payload,
-        });
-
-        expect(response).toHaveProperty('statusCode', HTTP_STATUS_CODES.OK);
-      },
-    );
-
-    test('Invalid access type should be refused', async () => {
-      const payload: OrgSchema = {
-        name: ORG_NAME,
-        memberAccessType: 'INVALID' as any,
-      };
-
-      const response = await serverInstance.inject({
-        ...injectionOptions,
-        payload,
-      });
-
-      expect(response).toHaveProperty('statusCode', HTTP_STATUS_CODES.BAD_REQUEST);
-    });
-
-    test('Missing access type should be refused', async () => {
-      const payload: Partial<OrgSchema> = {
-        name: ORG_NAME,
-      };
-
-      const response = await serverInstance.inject({
-        ...injectionOptions,
-        payload,
-      });
-
-      expect(response).toHaveProperty('statusCode', HTTP_STATUS_CODES.BAD_REQUEST);
-    });
-
     test.each([
       ['ASCII', AWALA_ENDPOINT],
       ['Non ASCII', NON_ASCII_AWALA_ENDPOINT],
     ])('%s Awala endpoint should be allowed', async (_type, awalaEndpoint: string) => {
-      const payload: OrgSchema = {
-        name: ORG_NAME,
-        memberAccessType: 'OPEN',
-        awalaEndpoint,
-      };
+      const payload: OrgSchema = { name: ORG_NAME, awalaEndpoint };
       mockCreateOrg.mockResolvedValueOnce({
         didSucceed: true,
 
@@ -200,7 +131,6 @@ describe('org routes', () => {
     test('Malformed awala endpoint should be refused', async () => {
       const payload: OrgSchema = {
         name: ORG_NAME,
-        memberAccessType: 'INVITE_ONLY',
         awalaEndpoint: 'MALFORMED_AWALA_ENDPOINT',
       };
       mockCreateOrg.mockResolvedValueOnce({
@@ -225,11 +155,7 @@ describe('org routes', () => {
     };
     const getOrgSuccessResponse = {
       didSucceed: true,
-
-      result: {
-        name: ORG_NAME,
-        memberAccessType: 'INVITE_ONLY',
-      },
+      result: { name: ORG_NAME },
     } as const;
 
     describe('Auth', () => {
@@ -310,26 +236,6 @@ describe('org routes', () => {
       expect(response.json()).toHaveProperty('type', OrgProblemType.ORG_NOT_FOUND);
     });
 
-    test.each(orgSchemaMemberAccessTypes)(
-      '%s access type should be accepted',
-      async (memberAccessType: OrgSchemaMemberAccessType) => {
-        const payload: OrgSchemaPatch = {
-          memberAccessType,
-        };
-        mockGetOrg.mockResolvedValueOnce(getOrgSuccessResponse);
-        mockUpdateOrg.mockResolvedValueOnce({
-          didSucceed: true,
-        });
-
-        const response = await serverInstance.inject({
-          ...injectionOptions,
-          payload,
-        });
-
-        expect(response).toHaveProperty('statusCode', HTTP_STATUS_CODES.NO_CONTENT);
-      },
-    );
-
     test.each([
       ['ASCII', AWALA_ENDPOINT],
       ['Non ASCII', NON_ASCII_AWALA_ENDPOINT],
@@ -361,7 +267,7 @@ describe('org routes', () => {
         'ORG',
         { ...injectionOptions, url: `/orgs/${ORG_NAME}` },
         getTestServerFixture,
-        { spy: mockGetOrg, result: { name: ORG_NAME, memberAccessType: 'INVITE_ONLY' } },
+        { spy: mockGetOrg, result: { name: ORG_NAME } },
       );
     });
 
@@ -371,11 +277,7 @@ describe('org routes', () => {
     ])('%s name should return an org', async (_type, name: string) => {
       const getOrgSuccessResponse: SuccessfulResult<OrgSchema> = {
         didSucceed: true,
-
-        result: {
-          name,
-          memberAccessType: 'INVITE_ONLY',
-        },
+        result: { name },
       };
 
       mockGetOrg.mockResolvedValueOnce(getOrgSuccessResponse);
@@ -423,7 +325,7 @@ describe('org routes', () => {
       beforeEach(() => {
         mockGetOrg.mockResolvedValueOnce({
           didSucceed: true,
-          result: { name: ORG_NAME, memberAccessType: 'INVITE_ONLY' },
+          result: { name: ORG_NAME },
         });
       });
 
@@ -438,11 +340,7 @@ describe('org routes', () => {
     test('Valid name should be accepted', async () => {
       mockGetOrg.mockResolvedValueOnce({
         didSucceed: true,
-
-        result: {
-          name: ORG_NAME,
-          memberAccessType: 'INVITE_ONLY',
-        },
+        result: { name: ORG_NAME },
       });
       mockDeleteOrg.mockResolvedValueOnce({
         didSucceed: true,

--- a/src/models/Org.model.ts
+++ b/src/models/Org.model.ts
@@ -1,16 +1,8 @@
 import { prop } from '@typegoose/typegoose';
 
-export enum MemberAccessType {
-  INVITE_ONLY = 'invite_only',
-  OPEN = 'open',
-}
-
 export class OrgModelSchema {
   @prop({ required: true, unique: true, index: true })
   public name!: string;
-
-  @prop({ required: true, enum: MemberAccessType })
-  public memberAccessType!: MemberAccessType;
 
   @prop()
   public awalaEndpoint?: string;

--- a/src/org.spec.ts
+++ b/src/org.spec.ts
@@ -2,12 +2,8 @@
 import { getModelForClass, type ReturnModelType } from '@typegoose/typegoose';
 import type { Connection } from 'mongoose';
 
-import { MemberAccessType, OrgModelSchema } from './models/Org.model.js';
-import {
-  type OrgSchema,
-  type OrgSchemaMemberAccessType,
-  orgSchemaMemberAccessTypes,
-} from './schemas/org.schema.js';
+import { OrgModelSchema } from './models/Org.model.js';
+import type { OrgSchema } from './schemas/org.schema.js';
 import { setUpTestDbConnection } from './testUtils/db.js';
 import { makeMockLogging, partialPinoLog } from './testUtils/logging.js';
 import { requireFailureResult, requireSuccessfulResult } from './testUtils/result.js';
@@ -20,7 +16,6 @@ import {
 import { getPromiseRejection } from './testUtils/jest.js';
 import type { ServiceOptions } from './serviceTypes.js';
 import { OrgProblemType } from './OrgProblemType.js';
-import { MEMBER_ACCESS_TYPE_MAPPING } from './orgTypes.js';
 import { createOrg, deleteOrg, getOrg, updateOrg } from './org.js';
 import { mockKms } from './testUtils/kms/mockKms.js';
 import { derSerialisePublicKey } from './utilities/webcrypto.js';
@@ -46,17 +41,11 @@ describe('org', () => {
 
   describe('createOrg', () => {
     test('Minimum required data should be stored', async () => {
-      const orgData: OrgSchema = {
-        name: ORG_NAME,
-        memberAccessType: 'INVITE_ONLY',
-      };
+      const orgData: OrgSchema = { name: ORG_NAME };
 
       await createOrg(orgData, serviceOptions);
 
-      const dbResult = await orgModel.exists({
-        name: ORG_NAME,
-        memberAccessType: MemberAccessType.INVITE_ONLY,
-      });
+      const dbResult = await orgModel.exists({ name: ORG_NAME });
       expect(dbResult).not.toBeNull();
       expect(mockLogging.logs).toContainEqual(
         partialPinoLog('info', 'Org created', { name: ORG_NAME }),
@@ -65,10 +54,7 @@ describe('org', () => {
 
     test('Non ASCII name should be allowed', async () => {
       const nonAsciiName = 'はじめよう.みんな';
-      const orgData: OrgSchema = {
-        name: nonAsciiName,
-        memberAccessType: 'INVITE_ONLY',
-      };
+      const orgData: OrgSchema = { name: nonAsciiName };
 
       const result = await createOrg(orgData, serviceOptions);
 
@@ -77,10 +63,7 @@ describe('org', () => {
 
     test('Malformed name should be refused', async () => {
       const malformedName = '192.168.0.0';
-      const orgData: OrgSchema = {
-        name: malformedName,
-        memberAccessType: 'INVITE_ONLY',
-      };
+      const orgData: OrgSchema = { name: malformedName };
 
       const result = await createOrg(orgData, serviceOptions);
 
@@ -94,17 +77,10 @@ describe('org', () => {
     });
 
     test('Clash with existing name should be refused', async () => {
-      const orgData: OrgSchema = {
-        name: ORG_NAME,
-        memberAccessType: 'INVITE_ONLY',
-      };
+      const orgData: OrgSchema = { name: ORG_NAME };
       await createOrg(orgData, serviceOptions);
 
-      // Use different data to make sure the creation operation isn't being deduped
-      const methodResult = await createOrg(
-        { ...orgData, memberAccessType: 'OPEN' },
-        serviceOptions,
-      );
+      const methodResult = await createOrg(orgData, serviceOptions);
 
       requireFailureResult(methodResult);
       expect(methodResult.reason).toBe(OrgProblemType.EXISTING_ORG_NAME);
@@ -115,33 +91,11 @@ describe('org', () => {
       );
     });
 
-    test.each(orgSchemaMemberAccessTypes)(
-      '%s access type should be allowed',
-      async (memberAccessType: OrgSchemaMemberAccessType) => {
-        const orgData: OrgSchema = {
-          name: ORG_NAME,
-          memberAccessType,
-        };
-
-        const methodResult = await createOrg(orgData, serviceOptions);
-
-        requireSuccessfulResult(methodResult);
-        const dbResult = await orgModel.findOne({
-          name: methodResult.result.name,
-        });
-        expect(dbResult?.memberAccessType).toBe(MEMBER_ACCESS_TYPE_MAPPING[memberAccessType]);
-      },
-    );
-
     test.each([
       ['ASCII', AWALA_ENDPOINT],
       ['Non ASCII', NON_ASCII_AWALA_ENDPOINT],
     ])('%s Awala endpoint should be allowed', async (_type, awalaEndpoint: string) => {
-      const orgData: OrgSchema = {
-        name: ORG_NAME,
-        memberAccessType: 'INVITE_ONLY',
-        awalaEndpoint,
-      };
+      const orgData: OrgSchema = { name: ORG_NAME, awalaEndpoint };
 
       const result = await createOrg(orgData, serviceOptions);
 
@@ -152,7 +106,6 @@ describe('org', () => {
       const malformedAwalaEndpoint = '192.168.0.0';
       const orgData: OrgSchema = {
         name: ORG_NAME,
-        memberAccessType: 'INVITE_ONLY',
         awalaEndpoint: malformedAwalaEndpoint,
       };
 
@@ -170,7 +123,6 @@ describe('org', () => {
     test('Returned id should match that of the database', async () => {
       const orgData: OrgSchema = {
         name: ORG_NAME,
-        memberAccessType: 'INVITE_ONLY',
         awalaEndpoint: AWALA_ENDPOINT,
       };
 
@@ -186,10 +138,7 @@ describe('org', () => {
 
     test('Record creation errors should be propagated', async () => {
       await connection.close();
-      const orgData: OrgSchema = {
-        name: ORG_NAME,
-        memberAccessType: 'INVITE_ONLY',
-      };
+      const orgData: OrgSchema = { name: ORG_NAME };
 
       const error = await getPromiseRejection(
         async () => createOrg(orgData, serviceOptions),
@@ -200,10 +149,7 @@ describe('org', () => {
     });
 
     describe('Key pair', () => {
-      const orgData: OrgSchema = {
-        name: ORG_NAME,
-        memberAccessType: 'INVITE_ONLY',
-      };
+      const orgData: OrgSchema = { name: ORG_NAME };
 
       test('Key pair should be generated', async () => {
         const kms = getMockKms();
@@ -241,23 +187,13 @@ describe('org', () => {
     test('Valid data should be updated', async () => {
       await orgModel.create({
         name: ORG_NAME,
-        memberAccessType: MemberAccessType.OPEN,
         awalaEndpoint: `a.${AWALA_ENDPOINT}`,
       });
 
-      await updateOrg(
-        ORG_NAME,
-        {
-          name: ORG_NAME,
-          memberAccessType: 'INVITE_ONLY',
-          awalaEndpoint: AWALA_ENDPOINT,
-        },
-        serviceOptions,
-      );
+      await updateOrg(ORG_NAME, { name: ORG_NAME, awalaEndpoint: AWALA_ENDPOINT }, serviceOptions);
 
       const dbResult = await orgModel.exists({
         name: ORG_NAME,
-        memberAccessType: MemberAccessType.INVITE_ONLY,
         awalaEndpoint: AWALA_ENDPOINT,
       });
 
@@ -273,18 +209,9 @@ describe('org', () => {
       ['ASCII', ORG_NAME],
       ['Non ASCII', NON_ASCII_ORG_NAME],
     ])('Matching %s name should be allowed', async (_type, name: string) => {
-      await orgModel.create({
-        name,
-        memberAccessType: MemberAccessType.INVITE_ONLY,
-      });
+      await orgModel.create({ name });
 
-      const response = await updateOrg(
-        name,
-        {
-          name,
-        },
-        serviceOptions,
-      );
+      const response = await updateOrg(name, { name }, serviceOptions);
 
       expect(response.didSucceed).toBeTrue();
     });
@@ -335,35 +262,11 @@ describe('org', () => {
       );
     });
 
-    test.each(orgSchemaMemberAccessTypes)(
-      '%s access type should be allowed',
-      async (memberAccessType: OrgSchemaMemberAccessType) => {
-        await orgModel.create({
-          name: ORG_NAME,
-          memberAccessType: MEMBER_ACCESS_TYPE_MAPPING[memberAccessType],
-        });
-
-        const response = await updateOrg(
-          ORG_NAME,
-          {
-            memberAccessType,
-          },
-          serviceOptions,
-        );
-
-        expect(response.didSucceed).toBeTrue();
-      },
-    );
-
     test.each([
       ['ASCII', AWALA_ENDPOINT],
       ['Non ASCII', NON_ASCII_AWALA_ENDPOINT],
     ])('%s Awala endpoint should be allowed', async (_type, awalaEndpoint: string) => {
-      await orgModel.create({
-        name: ORG_NAME,
-        memberAccessType: MemberAccessType.OPEN,
-        awalaEndpoint: AWALA_ENDPOINT,
-      });
+      await orgModel.create({ name: ORG_NAME, awalaEndpoint: AWALA_ENDPOINT });
 
       const response = await updateOrg(
         ORG_NAME,
@@ -380,11 +283,7 @@ describe('org', () => {
       const malformedAwalaEndpoint = 'MALFORMED_AWALA_ENDPOINT';
       const result = await updateOrg(
         ORG_NAME,
-        {
-          name: ORG_NAME,
-          memberAccessType: 'INVITE_ONLY',
-          awalaEndpoint: malformedAwalaEndpoint,
-        },
+        { name: ORG_NAME, awalaEndpoint: malformedAwalaEndpoint },
         serviceOptions,
       );
 
@@ -399,10 +298,7 @@ describe('org', () => {
 
     test('Record update errors should be propagated', async () => {
       await connection.close();
-      const orgData: OrgSchema = {
-        name: ORG_NAME,
-        memberAccessType: 'INVITE_ONLY',
-      };
+      const orgData: OrgSchema = { name: ORG_NAME };
 
       const error = await getPromiseRejection(
         async () => updateOrg(ORG_NAME, orgData, serviceOptions),
@@ -417,7 +313,6 @@ describe('org', () => {
     test('Existing name should return the corresponding data', async () => {
       await orgModel.create({
         name: ORG_NAME,
-        memberAccessType: MemberAccessType.OPEN,
         awalaEndpoint: AWALA_ENDPOINT,
       });
 
@@ -426,7 +321,6 @@ describe('org', () => {
       requireSuccessfulResult(result);
       expect(result.result).toMatchObject({
         name: ORG_NAME,
-        memberAccessType: 'OPEN',
         awalaEndpoint: AWALA_ENDPOINT,
       });
     });
@@ -448,10 +342,7 @@ describe('org', () => {
   });
 
   describe('deleteOrg', () => {
-    const orgData: OrgSchema = {
-      name: ORG_NAME,
-      memberAccessType: 'INVITE_ONLY',
-    };
+    const orgData: OrgSchema = { name: ORG_NAME };
 
     test('Existing name should remove org', async () => {
       await createOrg(orgData, serviceOptions);

--- a/src/orgTypes.ts
+++ b/src/orgTypes.ts
@@ -1,20 +1,3 @@
-import type { OrgSchema } from './schemas/org.schema.js';
-import { MemberAccessType } from './models/Org.model.js';
-
 export interface OrgCreationResult {
   name: string;
 }
-
-export const MEMBER_ACCESS_TYPE_MAPPING: {
-  [key in OrgSchema['memberAccessType']]: MemberAccessType;
-} = {
-  INVITE_ONLY: MemberAccessType.INVITE_ONLY,
-  OPEN: MemberAccessType.OPEN,
-} as const;
-
-export const REVERSE_MEMBER_ACCESS_MAPPING: {
-  [key in MemberAccessType]: OrgSchema['memberAccessType'];
-} = {
-  [MemberAccessType.INVITE_ONLY]: 'INVITE_ONLY',
-  [MemberAccessType.OPEN]: 'OPEN',
-};

--- a/src/schemas/org.schema.ts
+++ b/src/schemas/org.schema.ts
@@ -5,23 +5,15 @@ export const ORG_SCHEMA = {
 
   properties: {
     name: { type: 'string' },
-
-    memberAccessType: {
-      type: 'string',
-      enum: ['INVITE_ONLY', 'OPEN'],
-    },
-
     awalaEndpoint: { type: 'string' },
   },
 
-  required: ['name', 'memberAccessType'],
+  required: ['name'],
 } as const;
 export const ORG_SCHEMA_PATCH = {
   ...ORG_SCHEMA,
   required: [],
 } as const;
 
-export const orgSchemaMemberAccessTypes = ORG_SCHEMA.properties.memberAccessType.enum;
-export type OrgSchemaMemberAccessType = (typeof orgSchemaMemberAccessTypes)[number];
 export type OrgSchema = FromSchema<typeof ORG_SCHEMA>;
 export type OrgSchemaPatch = FromSchema<typeof ORG_SCHEMA_PATCH>;


### PR DESCRIPTION
We don't need that ever since we introduced member public key import tokens.