### PR TITLE
fix: Restrict any content type in Awala endpoint unless specifically allowed

### DIFF
--- a/src/api/routes/awala.routes.spec.ts
+++ b/src/api/routes/awala.routes.spec.ts
@@ -58,6 +58,24 @@ describe('awala routes', () => {
     expect(response).toHaveProperty('statusCode', HTTP_STATUS_CODES.UNSUPPORTED_MEDIA_TYPE);
   });
 
+  test('Content type application/json should resolve to unsupported media type error', async () => {
+    const response = await server.inject({
+      method: 'POST',
+      url: '/awala',
+      payload: {
+        publicKeyId: MEMBER_PUBLIC_KEY_MONGO_ID,
+        memberBundleStartDate: '2023-04-13T20:05:38.285Z',
+        awalaPda: AWALA_PDA,
+        signature: SIGNATURE,
+      },
+      headers: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        'content-type': 'application/json',
+      },
+    });
+    expect(response).toHaveProperty('statusCode', HTTP_STATUS_CODES.UNSUPPORTED_MEDIA_TYPE);
+  });
+
   describe('Member bundle request', () => {
     const validPayload = {
       publicKeyId: MEMBER_PUBLIC_KEY_MONGO_ID,

--- a/src/api/routes/awala.routes.spec.ts
+++ b/src/api/routes/awala.routes.spec.ts
@@ -62,12 +62,7 @@ describe('awala routes', () => {
     const response = await server.inject({
       method: 'POST',
       url: '/awala',
-      payload: {
-        publicKeyId: MEMBER_PUBLIC_KEY_MONGO_ID,
-        memberBundleStartDate: '2023-04-13T20:05:38.285Z',
-        awalaPda: AWALA_PDA,
-        signature: SIGNATURE,
-      },
+
       headers: {
         // eslint-disable-next-line @typescript-eslint/naming-convention
         'content-type': 'application/json',

--- a/src/api/routes/awala.routes.ts
+++ b/src/api/routes/awala.routes.ts
@@ -98,6 +98,8 @@ export default function registerRoutes(
   _opts: RouteOptions,
   done: PluginDone,
 ): void {
+  fastify.removeAllContentTypeParsers();
+
   fastify.addContentTypeParser(
     awalaRequestMessageTypeList,
     {
@@ -105,13 +107,6 @@ export default function registerRoutes(
     },
     fastify.getDefaultJsonParser('ignore', 'ignore'),
   );
-
-  fastify.addContentTypeParser('application/json', { parseAs: 'string' }, function (_req, _body, done) {
-      done({
-        statusCode: HTTP_STATUS_CODES.UNSUPPORTED_MEDIA_TYPE
-      }, undefined)
-  }
-  })
 
   fastify.route({
     method: ['POST'],
@@ -121,11 +116,6 @@ export default function registerRoutes(
       const contentType = awalaRequestMessageTypeList.find(
         (messageType) => messageType === request.headers['content-type'],
       );
-
-      if(!contentType){
-        await reply.code(HTTP_STATUS_CODES.UNSUPPORTED_MEDIA_TYPE).send();
-        return;
-      }
 
       const serviceOptions = {
         logger: this.log,

--- a/src/api/routes/awala.routes.ts
+++ b/src/api/routes/awala.routes.ts
@@ -106,6 +106,13 @@ export default function registerRoutes(
     fastify.getDefaultJsonParser('ignore', 'ignore'),
   );
 
+  fastify.addContentTypeParser('application/json', { parseAs: 'string' }, function (_req, _body, done) {
+      done({
+        statusCode: HTTP_STATUS_CODES.UNSUPPORTED_MEDIA_TYPE
+      }, undefined)
+  }
+  })
+
   fastify.route({
     method: ['POST'],
     url: '/awala',
@@ -114,6 +121,11 @@ export default function registerRoutes(
       const contentType = awalaRequestMessageTypeList.find(
         (messageType) => messageType === request.headers['content-type'],
       );
+
+      if(!contentType){
+        await reply.code(HTTP_STATUS_CODES.UNSUPPORTED_MEDIA_TYPE).send();
+        return;
+      }
 
       const serviceOptions = {
         logger: this.log,


### PR DESCRIPTION
fixes #111 