### PR TITLE
fix(awala): Make Google PubSub push endpoints work

### DIFF
--- a/src/awala/routes/awala.routes.spec.ts
+++ b/src/awala/routes/awala.routes.spec.ts
@@ -76,7 +76,7 @@ describe('Awala routes', () => {
         'content-type': 'INVALID_CONTENT_TYPE',
       },
     });
-    expect(response).toHaveProperty('statusCode', HTTP_STATUS_CODES.UNSUPPORTED_MEDIA_TYPE);
+    expect(response).toHaveProperty('statusCode', HTTP_STATUS_CODES.BAD_REQUEST);
   });
 
   test('Content type application/json should resolve to unsupported media type error', async () => {
@@ -89,7 +89,7 @@ describe('Awala routes', () => {
         'content-type': 'application/json',
       },
     });
-    expect(response).toHaveProperty('statusCode', HTTP_STATUS_CODES.UNSUPPORTED_MEDIA_TYPE);
+    expect(response).toHaveProperty('statusCode', HTTP_STATUS_CODES.BAD_REQUEST);
   });
 
   test('Missing headers should resolve into bad request', async () => {

--- a/src/awala/routes/awala.routes.ts
+++ b/src/awala/routes/awala.routes.ts
@@ -86,8 +86,6 @@ const awalaEventToProcessor: {
   [AwalaRequestMessageType.MEMBER_BUNDLE_REQUEST]: processMemberBundleRequest,
   [AwalaRequestMessageType.MEMBER_PUBLIC_KEY_IMPORT]: processMemberKeyImportRequest,
 };
-const awalaRequestMessageTypeList: AwalaRequestMessageType[] =
-  Object.values(AwalaRequestMessageType);
 
 export default function registerRoutes(
   fastify: FastifyTypedInstance,
@@ -95,13 +93,9 @@ export default function registerRoutes(
   done: PluginDone,
 ): void {
   fastify.removeAllContentTypeParsers();
-  fastify.addContentTypeParser(
-    awalaRequestMessageTypeList,
-    { parseAs: 'buffer' },
-    (_request, payload, next) => {
-      next(null, payload);
-    },
-  );
+  fastify.addContentTypeParser('*', { parseAs: 'buffer' }, (_request, payload, next) => {
+    next(null, payload);
+  });
 
   fastify.route({
     method: ['POST'],


### PR DESCRIPTION
We were running the content type validation too soon, using the request `Content-Type` instead of the content type of the CloudEvent.
