### PR TITLE
fix(awala): Emit bundle request event with payload of type `Buffer`

### DIFF
--- a/src/memberKeyImportToken.spec.ts
+++ b/src/memberKeyImportToken.spec.ts
@@ -161,12 +161,12 @@ describe('member key import token', () => {
 
       requireSuccessfulResult(result);
       expect(getEvents(EmitterChannel.BACKGROUND_QUEUE)).toContainEqual(
-        expect.objectContaining<Partial<CloudEvent<string>>>({
+        expect.objectContaining<Partial<CloudEvent<Buffer>>>({
           source: 'https://veraid.net/authority/awala-member-key-import',
           type: BUNDLE_REQUEST_TYPE,
           subject: AWALA_PEER_ID,
           datacontenttype: 'text/plain',
-          data: MEMBER_PUBLIC_KEY_MONGO_ID,
+          data: Buffer.from(MEMBER_PUBLIC_KEY_MONGO_ID),
         }),
       );
     });

--- a/src/memberKeyImportToken.ts
+++ b/src/memberKeyImportToken.ts
@@ -77,12 +77,12 @@ export async function processMemberKeyImportToken(
     };
   }
 
-  const event = new CloudEvent<string>({
+  const event = new CloudEvent<Buffer>({
     source: 'https://veraid.net/authority/awala-member-key-import',
     type: BUNDLE_REQUEST_TYPE,
     subject: peerId,
     datacontenttype: 'text/plain',
-    data: publicKeyCreationResult.result.id,
+    data: Buffer.from(publicKeyCreationResult.result.id),
   });
   const ceEmitter = await Emitter.init(EmitterChannel.BACKGROUND_QUEUE);
   await ceEmitter.emit(event);


### PR DESCRIPTION
Because Google PubSub doesn't support strings.